### PR TITLE
Refactored to use only one schema

### DIFF
--- a/db/models/products.js
+++ b/db/models/products.js
@@ -1,4 +1,5 @@
 var mongoose = require('mongoose');
+var reviewSchema = require('./reviews.js')
 
 var productSchema = mongoose.Schema({
   product_id: {
@@ -10,8 +11,9 @@ var productSchema = mongoose.Schema({
     left: String, // ex. 'too small'
     best: String, // ex. 'perfect!'
     right: String, // ex. 'too big'
-  }]
-})
+  }],
+  reviews: [reviewSchema]
+});
 
 var ProductModel = mongoose.model('Product', productSchema);
 

--- a/db/models/reviews.js
+++ b/db/models/reviews.js
@@ -1,7 +1,6 @@
 var mongoose = require('mongoose');
 
 var reviewSchema = mongoose.Schema({
-  product_id: Number,
   rating: Number,
   recommended: Boolean,
   created: Date,
@@ -20,15 +19,4 @@ var reviewSchema = mongoose.Schema({
   }]
 });
 
-var ReviewModel = mongoose.model('Review', reviewSchema);
-
-var insertOne = (review, next=()=>{}) => {
-  ReviewModel.create(review, next);
-};
-
-var removeAll = (next=()=>{}) => {
-  ReviewModel.db.dropCollection('reviews', next);
-}
-
-module.exports.insertOne = insertOne;
-module.exports.removeAll = removeAll;
+module.exports = reviewSchema;

--- a/seeding/seed.js
+++ b/seeding/seed.js
@@ -1,6 +1,5 @@
 var ratingCategoryData = require('./ratingCategoryData'); //array of objects
 var Products = require('../db/models/products.js');
-var Reviews = require('../db/models/reviews.js');
 var mongoose = require('mongoose');
 var fake = require('faker');
 
@@ -11,23 +10,6 @@ var shuffle = (arr) => {
     var j = Math.floor(Math.random() * (i + 1));
     [arr[i], arr[j]] = [arr[j], arr[i]];
   }
-};
-
-var seedProducts = (qty) => {
-  var products = [];
-
-  for (var i = 0; i < qty; i++) {
-    var categoryQty = Math.floor(Math.random() * 4) + 2; //min of 2, max of 5
-    shuffle(ratingCategoryData);
-    var product = {
-      product_id: i,
-      rating_categories: ratingCategoryData.slice(0, categoryQty)
-    };
-    Products.insertOne(product);
-    products.push(product);
-  }
-
-  return products;
 };
 
 var createImages = (maxQty) => {
@@ -41,42 +23,51 @@ var createImages = (maxQty) => {
   return images;
 }
 
-var seedReviews = (products, min, max) => {
+var createReviews = (rating_categories, min, max) => {
+  var reviews = [];
+  var reviewQty = Math.floor(Math.random() * (max - min)) + min;
 
-  for (var i = 0; i < products.length; i++) {
-    var reviewQty = Math.floor(Math.random() * (max - min)) + min;
-
-    for (var j = 0; j < reviewQty; j++) {
-      var rating = Math.floor(Math.random() * 5) + 1; //min of 1, max of 5
-      var review = {
-        product_id: products[i].product_id,
-        rating,
-        recommended: rating > 2 ? true : false,
-        created: fake.date.between('2017-03-01', new Date()),
-        username: fake.internet.userName(),
-        summary: fake.lorem.sentence(),
-        detail: fake.lorem.paragraph(),
-        verified: [true, false][Math.floor(Math.random() * 2)],
-        photos: createImages(4),
-        helpful: {
-          yes: Math.floor(Math.random() * 10),
-          no: Math.floor(Math.random() * 10)
-        },
-        category_ratings: products[i].rating_categories.map(category => {
-          return {
-            name: category.name,
-            rating: Math.floor(Math.random() * 5) + 1 //min of 1, max of 5
-          };
-        })
-      }
-      Reviews.insertOne(review);
+  for (var i = 0; i < reviewQty; i++) {
+    var rating = Math.floor(Math.random() * 5) + 1; //min of 1, max of 5
+    var review = {
+      rating,
+      recommended: rating > 2 ? true : false,
+      created: fake.date.between('2017-03-01', new Date()),
+      username: fake.internet.userName(),
+      summary: fake.lorem.sentence(),
+      detail: fake.lorem.paragraph(),
+      verified: [true, false][Math.floor(Math.random() * 2)],
+      photos: createImages(4),
+      helpful: {
+        yes: Math.floor(Math.random() * 10),
+        no: Math.floor(Math.random() * 10)
+      },
+      category_ratings: rating_categories.map(category => {
+        return {
+          name: category.name,
+          rating: Math.floor(Math.random() * 5) + 1 //min of 1, max of 5
+        };
+      })
     }
+    reviews.push(review);
   }
-}
 
-Products.removeAll(() => {
-  var products = seedProducts(100);
-  Reviews.removeAll(() => {
-    seedReviews(products, 2, 15);
-  });
-});
+  return reviews;
+};
+
+var seedProducts = (qty) => {
+
+  for (var i = 0; i < qty; i++) {
+    var categoryQty = Math.floor(Math.random() * 4) + 2; //min of 2, max of 5
+    var rating_categories = ratingCategoryData.slice(0, categoryQty);
+    shuffle(ratingCategoryData);
+    var product = {
+      product_id: i,
+      rating_categories,
+      reviews: createReviews(rating_categories, 2, 20) //defines min and max qty of reviews per product
+    };
+    Products.insertOne(product);
+  }
+};
+
+Products.removeAll(() => seedProducts(100));


### PR DESCRIPTION
Since Mongo doesn't deal with relational DBs, I've merged by reviews schema into my product schema. I also had to refactor my seeding script to only seed products, not both reviews and products like it was before.

I've tested this and confirmed that my seeding script works. Products are seeded into my DB in the structure defined by my schema.

Please let me know if you see any room for improvement here.